### PR TITLE
fix(android 12): Add explicit value for `android:exported`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
@@ -55,7 +56,8 @@
         </receiver>
 
        <!-- Used for Background Work -->
-       <receiver android:name="ninja.mirea.mireaapp.widget_channel.HomeWidgetBackgroundReceiver">
+       <receiver android:name="ninja.mirea.mireaapp.widget_channel.HomeWidgetBackgroundReceiver"
+        android:exported="true">
            <intent-filter>
                <action android:name="es.antonborri.home_widget.action.BACKGROUND" />
            </intent-filter>


### PR DESCRIPTION
Приложения, ориентированные на Android 12 и выше требуют явного указания значения для `android:exported` (https://developer.android.com/guide/topics/manifest/activity-element#exported)