### PR TITLE
ui: Add Bottom Navigation Bar Background

### DIFF
--- a/lib/data/datasources/user_remote.dart
+++ b/lib/data/datasources/user_remote.dart
@@ -27,6 +27,7 @@ class UserRemoteDataImpl implements UserRemoteData {
 
   UserRemoteDataImpl({required this.httpClient, required this.lksOauth2});
 
+  @override
   Future<String> auth() async {
     final token = await lksOauth2.oauth2Helper.getToken();
 

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -2,10 +2,8 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rtu_mirea_app/presentation/bloc/app_cubit/app_cubit.dart';
-import 'package:rtu_mirea_app/presentation/bloc/update_info_bloc/update_info_bloc.dart';
 import 'package:rtu_mirea_app/presentation/colors.dart';
 import 'package:rtu_mirea_app/presentation/core/routes/routes.gr.dart';
-import 'package:rtu_mirea_app/presentation/widgets/update_info_modal.dart';
 import 'package:salomon_bottom_bar/salomon_bottom_bar.dart';
 
 class HomePage extends StatelessWidget {
@@ -57,35 +55,38 @@ class AppBottomNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SalomonBottomBar(
-      margin: const EdgeInsets.symmetric(
-        horizontal: 10,
-        vertical: 10,
+    return Container(
+      color: DarkThemeColors.background01,
+      child: SalomonBottomBar(
+        margin: const EdgeInsets.symmetric(
+          horizontal: 10,
+          vertical: 10,
+        ),
+        currentIndex: index,
+        onTap: onClick,
+        items: [
+          SalomonBottomBarItem(
+            icon: const Icon(Icons.library_books_rounded),
+            title: const Text("Новости"),
+            selectedColor: DarkThemeColors.primary,
+          ),
+          SalomonBottomBarItem(
+            icon: const Icon(Icons.calendar_today_rounded),
+            title: const Text("Расписание"),
+            selectedColor: DarkThemeColors.primary,
+          ),
+          SalomonBottomBarItem(
+            icon: const Icon(Icons.map_rounded),
+            title: const Text("Карта"),
+            selectedColor: DarkThemeColors.primary,
+          ),
+          SalomonBottomBarItem(
+            icon: const Icon(Icons.person),
+            title: const Text("Профиль"),
+            selectedColor: DarkThemeColors.primary,
+          ),
+        ],
       ),
-      currentIndex: index,
-      onTap: onClick,
-      items: [
-        SalomonBottomBarItem(
-          icon: const Icon(Icons.library_books_rounded),
-          title: const Text("Новости"),
-          selectedColor: DarkThemeColors.primary,
-        ),
-        SalomonBottomBarItem(
-          icon: const Icon(Icons.calendar_today_rounded),
-          title: const Text("Расписание"),
-          selectedColor: DarkThemeColors.primary,
-        ),
-        SalomonBottomBarItem(
-          icon: const Icon(Icons.map_rounded),
-          title: const Text("Карта"),
-          selectedColor: DarkThemeColors.primary,
-        ),
-        SalomonBottomBarItem(
-          icon: const Icon(Icons.person),
-          title: const Text("Профиль"),
-          selectedColor: DarkThemeColors.primary,
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -13,7 +13,6 @@ import '../../bloc/profile_bloc/profile_bloc.dart';
 import '../../theme.dart';
 import '../../widgets/buttons/text_outlined_button.dart';
 import '../../widgets/container_label.dart';
-import 'widgets/bottom_error_info.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class ProfilePage extends StatefulWidget {

--- a/lib/presentation/pages/profile/profile_scores_page.dart
+++ b/lib/presentation/pages/profile/profile_scores_page.dart
@@ -6,7 +6,6 @@ import 'package:rtu_mirea_app/presentation/bloc/scores_bloc/scores_bloc.dart';
 import 'package:rtu_mirea_app/presentation/colors.dart';
 import 'package:rtu_mirea_app/presentation/pages/profile/widgets/scores_chart_modal.dart';
 import 'package:rtu_mirea_app/presentation/theme.dart';
-import 'package:rtu_mirea_app/presentation/widgets/buttons/text_outlined_button.dart';
 import 'package:syncfusion_flutter_datagrid/datagrid.dart';
 import 'package:rtu_mirea_app/presentation/widgets/buttons/primary_tab_button.dart';
 


### PR DESCRIPTION
У нижней навигационной панели не было цвета, что хорошо заметно на страницах, у которых фон отличается от стандартного. Например, на странице карты навигационная панель просвечивалась.

Было:
![image](https://user-images.githubusercontent.com/51058739/214145895-7ed58841-47f6-450d-8e24-b055ef176605.png)

Стало:
![image](https://user-images.githubusercontent.com/51058739/214145945-564f22b9-11a2-46a4-a11e-a9516d05fffa.png)
