### PR TITLE
fix: Add nullable image formats from CMS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.0.5'
+          flutter-version: '3.3.10'
       - run: flutter pub get
       - name: Run Tests
         run: flutter test

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.0.5'
+          flutter-version: '3.3.10'
       - run: flutter pub get
       - name: Run Tests
         run: flutter test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
       with:
-        flutter-version: '3.0.5'
+        flutter-version: '3.3.10'
         channel: 'stable' # or: 'beta', 'dev' or 'master'
     - run: flutter pub get
     - run: flutter test ./test/mirea_test.dart

--- a/lib/data/models/strapi_media_model.dart
+++ b/lib/data/models/strapi_media_model.dart
@@ -30,7 +30,9 @@ class StrapiMediaModel extends StrapiMedia {
         caption: json["caption"],
         width: json["width"],
         height: json["height"],
-        formats: FormatsModel.fromJson(json["formats"]),
+        formats: json["formats"] != null
+            ? FormatsModel.fromJson(json["formats"])
+            : null,
         size: json["size"].toDouble(),
         url: json["url"],
       );

--- a/lib/domain/entities/story.dart
+++ b/lib/domain/entities/story.dart
@@ -57,11 +57,11 @@ class Author extends Equatable {
   });
 
   final String name;
-  final String url;
+  final String? url;
   final StrapiMedia logo;
 
   @override
-  List<Object> get props => [name, url, logo];
+  List<Object> get props => [name, logo];
 }
 
 class StoryPageAction extends Equatable {

--- a/lib/domain/entities/strapi_media.dart
+++ b/lib/domain/entities/strapi_media.dart
@@ -17,12 +17,12 @@ class StrapiMedia extends Equatable {
   final String? caption;
   final int width;
   final int height;
-  final Formats formats;
+  final Formats? formats;
   final double size;
   final String url;
 
   @override
-  List<Object> get props => [name, width, height, formats, size, url];
+  List<Object> get props => [name, width, height, size, url];
 }
 
 class Formats extends Equatable {

--- a/lib/presentation/pages/news/news_details_page.dart
+++ b/lib/presentation/pages/news/news_details_page.dart
@@ -29,7 +29,10 @@ class NewsDetailsPage extends StatelessWidget {
                 children: <Widget>[
                   Positioned.fill(
                     child: Image.network(
-                      StrapiUtils.getMediumImageUrl(newsItem.images[0].formats),
+                      newsItem.images[0].formats != null
+                          ? StrapiUtils.getMediumImageUrl(
+                              newsItem.images[0].formats!)
+                          : newsItem.images[0].url,
                       fit: BoxFit.cover,
                     ),
                   ),

--- a/lib/presentation/pages/news/widgets/news_item.dart
+++ b/lib/presentation/pages/news/widgets/news_item.dart
@@ -43,7 +43,9 @@ class NewsItemWidget extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               ExtendedImage.network(
-                StrapiUtils.getMediumImageUrl(newsItem.images[0].formats),
+                newsItem.images[0].formats != null
+                    ? StrapiUtils.getMediumImageUrl(newsItem.images[0].formats!)
+                    : newsItem.images[0].url,
                 height: 175,
                 width: MediaQuery.of(context).size.width,
                 fit: BoxFit.cover,

--- a/lib/presentation/pages/news/widgets/stories_wrapper.dart
+++ b/lib/presentation/pages/news/widgets/stories_wrapper.dart
@@ -56,12 +56,19 @@ class _StoriesWrapperState extends State<StoriesWrapper> {
                     child: Container(color: Colors.black),
                   ),
                   Positioned.fill(
-                    child: Image.network(
-                      MediaQuery.of(context).size.width > 580
-                          ? StrapiUtils.getLargestImageUrl(page.media.formats)
-                          : StrapiUtils.getMediumImageUrl(page.media.formats),
-                      fit: BoxFit.cover,
-                    ),
+                    child: page.media.formats != null
+                        ? Image.network(
+                            MediaQuery.of(context).size.width > 580
+                                ? StrapiUtils.getLargestImageUrl(
+                                    page.media.formats!)
+                                : StrapiUtils.getMediumImageUrl(
+                                    page.media.formats!),
+                            fit: BoxFit.cover,
+                          )
+                        : Image.network(
+                            page.media.url,
+                            fit: BoxFit.cover,
+                          ),
                   ),
                   Padding(
                     padding: const EdgeInsets.only(top: 44, left: 8),
@@ -72,10 +79,12 @@ class _StoriesWrapperState extends State<StoriesWrapper> {
                           width: 32,
                           decoration: BoxDecoration(
                             image: DecorationImage(
-                              image: NetworkImage(
-                                  author.logo.formats.small != null
-                                      ? author.logo.formats.small!.url
-                                      : author.logo.formats.thumbnail.url),
+                              image: author.logo.formats != null
+                                  ? NetworkImage(
+                                      author.logo.formats!.small != null
+                                          ? author.logo.formats!.small!.url
+                                          : author.logo.formats!.thumbnail.url)
+                                  : NetworkImage(author.logo.url),
                               fit: BoxFit.cover,
                             ),
                             shape: BoxShape.circle,

--- a/lib/presentation/pages/news/widgets/story_item.dart
+++ b/lib/presentation/pages/news/widgets/story_item.dart
@@ -31,10 +31,12 @@ class StoryWidget extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
             image: DecorationImage(
               fit: BoxFit.cover,
-              image: NetworkImage(
-                  stories[storyIndex].preview.formats.small != null
-                      ? stories[storyIndex].preview.formats.small!.url
-                      : stories[storyIndex].preview.formats.thumbnail.url),
+              image: stories[storyIndex].preview.formats != null
+                  ? NetworkImage(
+                      stories[storyIndex].preview.formats!.small != null
+                          ? stories[storyIndex].preview.formats!.small!.url
+                          : stories[storyIndex].preview.formats!.thumbnail.url)
+                  : NetworkImage(stories[storyIndex].preview.url),
               colorFilter: ColorFilter.mode(
                   DarkThemeColors.background02.withOpacity(0.15),
                   BlendMode.dstOut),

--- a/lib/presentation/widgets/images_horizontal_slider.dart
+++ b/lib/presentation/widgets/images_horizontal_slider.dart
@@ -26,8 +26,10 @@ class ImagesHorizontalSlider extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (_) => FullScreenImage(
-                      imageUrl:
-                          StrapiUtils.getLargestImageUrl(images[index].formats),
+                      imageUrl: images[index].formats != null
+                          ? StrapiUtils.getLargestImageUrl(
+                              images[index].formats!)
+                          : images[index].url,
                     ),
                   ),
                 );
@@ -37,7 +39,9 @@ class ImagesHorizontalSlider extends StatelessWidget {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(12.0),
                   child: Image.network(
-                    images[index].formats.thumbnail.url,
+                    images[index].formats != null
+                        ? images[index].formats!.thumbnail.url
+                        : images[index].url,
                     height: 112,
                     width: 158,
                     fit: BoxFit.cover,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
 
   # Internet connection checker.
   # See https://pub.dev/packages/internet_connection_checker
-  internet_connection_checker: ^0.0.1+3
+  internet_connection_checker: ^1.0.0+1
 
   # Functional Programming in Dart
   # See https://pub.dev/packages/dartz/versions/0.10.0-nullsafety.2
@@ -103,7 +103,7 @@ dependencies:
   # Creates page that is dismissed by swipe gestures, with Hero style
   # animations, Inspired by Facebook, Instagram stories.
   # See https://pub.dev/packages/dismissible_page
-  dismissible_page: ^0.7.3
+  dismissible_page: ^1.0.1
   
   # Instagram stories like UI with rich animations and customizability.
   # See https://pub.dev/packages/story
@@ -146,7 +146,7 @@ dependencies:
 
   # Get version name in runtime
   # https://pub.dev/packages/package_info_plus
-  package_info_plus: ^1.3.0
+  package_info_plus: ^3.0.2
 
   # Encapsulates the notion of the "current time". Very useful for testing
   # See https://pub.dev/packages/clock
@@ -162,7 +162,7 @@ dependencies:
   get_storage:
 
   # https://pub.dev/packages/home_widget
-  home_widget: ^0.1.6
+  home_widget: ^0.2.0+1
   
   freezed_annotation: ^2.1.0
 
@@ -186,7 +186,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  flutter_launcher_icons: ^0.10.0
+  flutter_launcher_icons: ^0.11.0
   auto_route_generator: ^5.0.2
   build_runner:
   # https://pub.dev/packages/freezed


### PR DESCRIPTION
Не все типы изображений могут быть оптимизированы. Например, svg изображения не форматируются, поэтому formats у них возвращается null.
