### PR TITLE
fix: Disable Secure Storage Android backups

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
    <application
         android:label="Ninja Mirea"
         android:usesCleartextTraffic="true"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:fullBackupContent="@xml/backup_rules">
         <activity android:name="com.linusu.flutter_web_auth_2.CallbackActivity" android:exported="true">
             <intent-filter android:label="flutter_web_auth_2">
                 <action android:name="android.intent.action.VIEW" />

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- Exclude FlutterSecureStorage (plugin) from backup -->
+    <exclude domain="sharedpref" path="FlutterSecureStorage"/>
+</full-backup-content>


### PR DESCRIPTION
По умолчанию Android создает резервные копии данных на Google Диске. Это может вызвать исключение `java.security.InvalidKeyException:Failed to unwrap key` при использовании Secure Storage.