### PR TITLE
ui: Fix status text overflow in profile

### DIFF
--- a/lib/presentation/pages/profile/profile_detail_page.dart
+++ b/lib/presentation/pages/profile/profile_detail_page.dart
@@ -62,30 +62,30 @@ class ProfileDetailPage extends StatelessWidget {
                         SizedBox(
                           width: 160,
                           child: BadgedContainer(
-                              label: 'Группа',
-                              text: student.academicGroup,
-                              onClick: () {}),
+                            label: 'Группа',
+                            text: student.academicGroup,
+                          ),
                         ),
                         SizedBox(
                           width: 160,
                           child: BadgedContainer(
-                              label: 'Личный номер',
-                              text: student.personalNumber,
-                              onClick: () {}),
+                            label: 'Личный номер',
+                            text: student.personalNumber,
+                          ),
                         ),
                         SizedBox(
                           width: 160,
                           child: BadgedContainer(
-                              label: 'Курс',
-                              text: student.course.toString(),
-                              onClick: () {}),
+                            label: 'Курс',
+                            text: student.course.toString(),
+                          ),
                         ),
                         SizedBox(
                           width: 160,
                           child: BadgedContainer(
-                              label: 'Состояние',
-                              text: student.status,
-                              onClick: () {}),
+                            label: 'Состояние',
+                            text: student.status,
+                          ),
                         ),
                       ]),
                 ),

--- a/lib/presentation/widgets/badged_container.dart
+++ b/lib/presentation/widgets/badged_container.dart
@@ -5,42 +5,48 @@ import 'package:rtu_mirea_app/presentation/typography.dart';
 class BadgedContainer extends StatelessWidget {
   final String label;
   final String text;
-  final VoidCallback? onClick;
 
-  const BadgedContainer(
-      {Key? key, required this.label, required this.text, this.onClick})
+  const BadgedContainer({Key? key, required this.label, required this.text})
       : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: double.infinity,
+      width: 160,
       height: 90,
       child: Card(
         color: AppTheme.colors.background02,
         margin: const EdgeInsets.all(0),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(10),
-          onTap: onClick,
-          child: Padding(
-            padding: const EdgeInsets.all(20.0),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const SizedBox(height: 20),
-                Column(
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 20),
+              SizedBox(
+                width: 120,
+                child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(label,
-                        style: AppTextStyle.bodyBold
-                            .copyWith(color: AppTheme.colors.deactive)),
+                    Text(
+                      label,
+                      style: AppTextStyle.bodyBold.copyWith(
+                        color: AppTheme.colors.deactive,
+                      ),
+                    ),
                     const SizedBox(height: 5),
-                    Text(text, style: AppTextStyle.title)
+                    Text(
+                      text,
+                      style: AppTextStyle.title,
+                      maxLines: 1,
+                      textAlign: TextAlign.start,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ],
-                )
-              ],
-            ),
+                ),
+              )
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
Было:
![image](https://user-images.githubusercontent.com/51058739/232463811-858b2a4c-0fce-4d0a-8b67-333ce26a4fa1.png)

Стало:
![image](https://user-images.githubusercontent.com/51058739/232463834-c59d75ab-5d83-444f-89bb-8b202586b79d.png)
