### PR TITLE
ui: Add types padding and update indicators sizes

### DIFF
--- a/lib/presentation/pages/schedule/widgets/lesson_card.dart
+++ b/lib/presentation/pages/schedule/widgets/lesson_card.dart
@@ -89,7 +89,9 @@ class LessonCard extends StatelessWidget {
                 ],
               ),
             ),
-            Container(),
+            SizedBox(
+              width: 8,
+            ),
             Container(
               alignment: Alignment.topRight,
               child: Container(

--- a/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
@@ -190,6 +190,7 @@ class _SchedulePageViewState extends State<SchedulePageView> {
         TableCalendar(
           // pageJumpingEnabled: true,
           weekendDays: const [DateTime.sunday],
+
           calendarBuilders: CalendarBuilders(
             markerBuilder: (context, day, events) {
               return Row(
@@ -231,6 +232,8 @@ class _SchedulePageViewState extends State<SchedulePageView> {
           ),
           calendarStyle: CalendarStyle(
             rangeHighlightColor: AppTheme.colors.secondary,
+            cellAlignment: Alignment.center,
+            cellMargin: const EdgeInsets.all(10),
           ),
           daysOfWeekStyle: DaysOfWeekStyle(
             weekdayStyle:


### PR DESCRIPTION
* Добавлен небольшой отступ для типа предмета в карточке расписания, чтобы текст не соприкасался с лейблом типа предмета
![image](https://github.com/mirea-ninja/rtu-mirea-mobile/assets/51058739/40e2e603-bcbd-4038-87f4-de2107aaf1cc)
* Уменьшен размер круговых индикаторов календаря, чтобы они не соприкасались с индикаторами событий
![image](https://github.com/mirea-ninja/rtu-mirea-mobile/assets/51058739/67ec7107-aaea-4583-9cfb-9c05fdb9d11c)
